### PR TITLE
[tech] Use action-rs/audit-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,17 @@ jobs:
     - name: Linting
       run: make lint
 
+  audit:
+    name: Audits
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v1
+    - name: Security audit
+      uses: actions-rs/audit-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
   tests:
     name: Tests
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Only as a warning/reminder to be consulted, not blocking

Currently:
* failure is deprecated/unmaintained (already identified to be replaced)
* term (brought by slog-term) is looking for maintainer since end of 2018

Test locally how it behaves